### PR TITLE
Modernize HappyCat into a professional, reproducible ML baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+artifacts/
+*.pkl
+*.json

--- a/README.md
+++ b/README.md
@@ -1,14 +1,67 @@
 # HappyCat
 
-<img align="right" src="https://github.com/sparktsao/HappyCat/blob/master/happycat.jpg?raw=true">
-## Introduction
-* a example project about machine leanring
+A compact, recruiter-friendly machine learning project that demonstrates a clean malware-classification workflow on tabular features.
 
-## Learning
-* cd learning
-* python happycat.py ../dataset/unittest/ 2 unittest
+![HappyCat](happycat.jpg)
 
-## Detection
-* cd detection
-* python runwin.py modelfile parameterfile target-foler fmodule
-* python runwin.py target-folder
+## What this project shows
+
+- Binary classification (`normal` vs `malicious`) on `.vlog` feature files.
+- Reproducible training with deterministic shuffling and model configuration.
+- K-fold cross-validation, train/test evaluation, and metrics serialization.
+- Production-like outputs (`.pkl` model + `.json` metrics) in an artifacts directory.
+
+## Project structure
+
+- `learning/happycat.py`: training entrypoint and CLI.
+- `learning/learning_kernel.py`: data loading, model building, CV, and artifact saving.
+- `dataset/unittest/`: sample dataset.
+
+## Requirements
+
+- Python 3.9+
+- `numpy`, `pandas`, `scikit-learn`
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Quickstart
+
+From repository root:
+
+```bash
+python learning/happycat.py \
+  --dataset dataset/unittest \
+  --folds 3 \
+  --run-name unittest_demo
+```
+
+Outputs:
+
+- `artifacts/unittest_demo_model.pkl`
+- `artifacts/unittest_demo_metrics.json`
+
+## Example command options
+
+```bash
+python learning/happycat.py \
+  --dataset dataset/unittest \
+  --folds 5 \
+  --drop-columns 1,3,8 \
+  --output-dir artifacts \
+  --run-name my_experiment
+```
+
+## Notes for interview/review context
+
+This project intentionally uses a **strong baseline model** (`LogisticRegression`) and emphasizes:
+
+- readability,
+- reproducibility,
+- metrics quality,
+- and clean CLI ergonomics.
+
+That keeps the repository focused on software engineering quality while still demonstrating practical ML workflow fundamentals.

--- a/learning/happycat.py
+++ b/learning/happycat.py
@@ -1,78 +1,114 @@
-# date: 2016/04/01
-# username: spark
-# description: learning fundation
+"""Train a baseline malware classifier on HappyCat `.vlog` datasets.
 
-import os
-import sys
+Example:
+    python learning/happycat.py --dataset dataset/unittest --folds 3 --run-name unittest
+"""
 
-import numpy as np
-import timeit
+from __future__ import annotations
 
-from keras.utils import np_utils, generic_utils
-from keras.models import Sequential
-from keras.layers.core import Dense, Dropout, Activation
-from keras.optimizers import SGD
-from keras.callbacks import EarlyStopping
-from keras.callbacks import Callback
+import argparse
+from pathlib import Path
+from statistics import mean
 
-from sklearn.cross_validation import KFold
-
-import pandas
-
-import learning_kernel as sparkcore
-
-#========================================
-# General parameters
-sparkcore.bBalance = False
-dropcolumns = []
-#========================================
-
-if len(sys.argv)>=2:
-    path1 = sys.argv[1]
-else:
-    print "Please run as %s vlog-folder" % sys.argv[0]
-    exit(1)
-if len(sys.argv)>=3:
-    sparkcore.nb_folds = int(sys.argv[2])
-if len(sys.argv)>=4:
-    sparkcore.NOTE = sys.argv[3]
-if len(sys.argv)>=5:
-    dropcolumns= sys.argv[4].split(",")
-
-class RandomCat:
-    def fit(self,trainingdata,traininglabel):
-        return 0
-    def predict(self,testdata):
-        import random
-        r = [random.randint(0,1) for x in testdata]
-        return np.asarray(r)
-    def to_json(self):
-        return "meow"
-    def save_weights(self,a,overwrite=True):
-        return "meow"
-       
-def TrainAndValidation1(X_train,y_train,X_test,y_test,bEarlyStopByTestData=True):
-    
-    print "Training shape:" , X_train.shape
-    print "Training label:" , y_train.shape   
-
-    model = RandomCat() 
-    model.fit(X_train,y_train.ravel())
-    if not X_test is None:
-        predicted = model.predict(X_test)
-        v_precision,v_recall,TP, FP, TN, FN = sparkcore.MyEvaluation(y_test,predicted)
-        return 0,0,v_precision,v_recall,TP, FP, TN, FN, model
-    else:
-        return 0,0,0,0,0,0,0,0, model
+from learning_kernel import (
+    build_model,
+    cross_validate,
+    evaluate,
+    load_dataset,
+    save_artifacts,
+)
 
 
-if  __name__ == '__main__':    
-    bMulticlass = False
-    logdata = sparkcore.ExpFunc(path1,TrainAndValidation1,bMulticlass,dropcolumns)
-    #============================================================================================    
-    logdata.logModel = ("")
-    #============================================================================================
-    logdata.doprint()
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="HappyCat baseline training entrypoint")
+    parser.add_argument("--dataset", required=True, help="Path to dataset directory")
+    parser.add_argument("--folds", type=int, default=5, help="Number of CV folds")
+    parser.add_argument("--run-name", default="happycat", help="Name prefix for saved artifacts")
+    parser.add_argument(
+        "--output-dir",
+        default="artifacts",
+        help="Directory to save model and metrics artifacts",
+    )
+    parser.add_argument(
+        "--drop-columns",
+        default="",
+        help="Comma-separated 1-based feature indices to remove (example: 1,2,5)",
+    )
+    parser.add_argument(
+        "--test-subdir",
+        default="test",
+        help="Optional test sub-directory inside --dataset",
+    )
+    return parser.parse_args()
 
 
+def _parse_drop_columns(raw: str) -> list[int]:
+    if not raw.strip():
+        return []
+    return [int(piece.strip()) for piece in raw.split(",") if piece.strip()]
 
+
+def main() -> None:
+    args = parse_args()
+    drop_columns = _parse_drop_columns(args.drop_columns)
+
+    train_data = load_dataset(args.dataset, drop_columns=drop_columns)
+
+    cv_results = cross_validate(train_data, folds=args.folds)
+    cv_summary = {
+        "precision_mean": mean([r.precision for r in cv_results]),
+        "recall_mean": mean([r.recall for r in cv_results]),
+        "f1_mean": mean([r.f1 for r in cv_results]),
+    }
+
+    model = build_model()
+    model.fit(train_data.features, train_data.labels)
+
+    train_eval = evaluate(model, train_data.features, train_data.labels)
+
+    metrics: dict = {
+        "dataset": args.dataset,
+        "folds": args.folds,
+        "drop_columns": drop_columns,
+        "cv_summary": cv_summary,
+        "train": {
+            "precision": train_eval.precision,
+            "recall": train_eval.recall,
+            "f1": train_eval.f1,
+            "confusion_matrix": train_eval.confusion.tolist(),
+            "classification_report": train_eval.report,
+        },
+    }
+
+    test_dir = Path(args.dataset) / args.test_subdir
+    if test_dir.exists():
+        test_data = load_dataset(test_dir, drop_columns=drop_columns)
+        test_eval = evaluate(model, test_data.features, test_data.labels)
+        metrics["test"] = {
+            "precision": test_eval.precision,
+            "recall": test_eval.recall,
+            "f1": test_eval.f1,
+            "confusion_matrix": test_eval.confusion.tolist(),
+            "classification_report": test_eval.report,
+        }
+
+    model_path, metrics_path = save_artifacts(
+        model,
+        metrics,
+        output_dir=args.output_dir,
+        run_name=args.run_name,
+    )
+
+    print("=== Cross-validation summary ===")
+    print(cv_summary)
+    print("=== Train report ===")
+    print(train_eval.report)
+    if "test" in metrics:
+        print("=== Test report ===")
+        print(metrics["test"]["classification_report"])
+    print(f"Saved model: {model_path}")
+    print(f"Saved metrics: {metrics_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/learning/learning_kernel.py
+++ b/learning/learning_kernel.py
@@ -1,324 +1,164 @@
-# date: 2016/04/01
-# username: spark
-# description: learning fundation
-import sys
-import os
+"""Core training utilities for the HappyCat malware-classification demo.
+
+This module provides:
+- dataset loading from `.vlog` files
+- binary label generation (malicious vs normal)
+- model training helpers
+- evaluation and reporting helpers
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+import json
+import pickle
+
 import numpy as np
-from sklearn.metrics import classification_report
-from sklearn.metrics import precision_score
-from sklearn.metrics import recall_score
-from sklearn.cross_validation import KFold
-import timeit
-import datetime
-import pandas
-import random
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import (
+    classification_report,
+    confusion_matrix,
+    f1_score,
+    precision_score,
+    recall_score,
+)
+from sklearn.model_selection import KFold
 
-KLABEL = {"malicious":1,"normal":0,"spark":2}
-WORKING_KLABEL = 2
-B_MULTICLASS = False
-#========================================
-# General parameters
-nb_folds = 10
-bBalance = False
-NOTE = 'youcanreplaceme'
-
-ARR_score0 = []
-ARR_score1 = []
-ARR_rtime = []
-ARR_tr_precision = []
-ARR_tr_recall = []
-ARR_4N = []
-#========================================
+LABEL_MAP: Dict[str, int] = {"normal": 0, "malicious": 1}
 
 
-def parsefile(f,flag):
-    print "#\tPandas Parsefile:", f, flag
-    f1 = pandas.read_csv(f,comment="#",header=None,engine='c')
-    f1.columns = ["sha1"]+f1.columns.tolist()[1:]
-    f1 = f1[f1.sha1!='sha1'] # remove possible header
-    
-    data = f1.ix[:,1:] # remove sha1
-    data = data.fillna(0)
-    da = np.array(data,dtype="float64")
-    return da
+@dataclass
+class Dataset:
+    features: np.ndarray
+    labels: np.ndarray
+    feature_names: List[str]
 
 
-def PrepareLabel1(n,ismalicious):
-    if ismalicious:
-        l1 = [[1] for i in range(n)]
-    else:
-        l1 = [[0] for i in range(n)]
-    return l1
+@dataclass
+class EvaluationResult:
+    precision: float
+    recall: float
+    f1: float
+    confusion: np.ndarray
+    report: str
 
 
-def PrepareLabelN(nrecords,glabel,ng):
-    r1 = [0]*ng
-    r1[glabel]=1
-    r2 = [r1 for i in range(nrecords)]
-    return r2
+def _parse_vlog_file(path: Path) -> pd.DataFrame:
+    """Parse a `.vlog` file and drop the leading sha1 column."""
+    df = pd.read_csv(path, comment="#", header=None, engine="c")
+    if df.empty:
+        raise ValueError(f"Empty dataset file: {path}")
 
-def Process(path1,bBalance=False,bIsMulticlass=True,dropcolumns=[]):
-    ngroup = 0
-    for fname in os.listdir(path1):
-        if not fname.endswith(".vlog"): continue
-        flabel = fname.split(".")[0]
-        if False==( flabel in KLABEL): continue
-
-        ngroup = ngroup + 1
-
-    global WORKING_KLABEL
-    WORKING_KLABEL = ngroup
-
-    data = None
-    label = None    
-    for fname in os.listdir(path1):
-        if not fname.endswith(".vlog"): continue
-        flabel = fname.split(".")[0]
-        if False==( flabel in KLABEL): continue
-        ix = KLABEL[flabel]
-        if bIsMulticlass==False and ix>1: continue
-        d2 = parsefile(path1+fname,ix)
-        if bIsMulticlass:
-            l1 = PrepareLabelN(d2.shape[0],ix,ngroup)
-        else:
-            l1 = PrepareLabel1(d2.shape[0],ix)
-        l2 = np.array(l1,dtype="uint8")
-        if data is None:
-            data = d2
-            label = l2
-        else:
-            data = np.append(data,d2,axis=0)
-            label = np.append(label,l2,axis=0)
-
-    if len(data)==0: 
-        print "no data"
-        exit()
-
-    random.seed(1571)
-    index = [i for i in range(len(data))]
-    random.shuffle(index)
-    data = data[index]
-    label = label[index]
-
-    s1 =  data.shape
-    dropcolumns = [int(x)-1 for x in dropcolumns] # shift x-1 due to remove sha1
-    data = np.delete(data,dropcolumns,axis=1)
-    print "#\tdrop", s1, dropcolumns, " to ",data.shape
-    return data,label
-        
-
-def perf_measure(y_actual, y_hat,focusix):
-    TP,FP,TN,FN = 0,0,0,0
-    if len(y_actual[0])==1:
-        for i in range(len(y_hat)):
-            if y_actual[i]==y_hat[i]==1:
-               TP += 1
-            elif y_actual[i]==1 and y_actual[i]!=y_hat[i]:
-               FN += 1
-            if y_actual[i]==y_hat[i]==0:
-               TN += 1
-            elif y_actual[i]==0 and y_actual[i]!=y_hat[i]:
-               FP += 1
-        return(TP, FP, TN, FN)
-
-    for i in range(len(y_hat)): 
-        if np.all(y_actual[i]==y_hat[i]) and y_hat[i][focusix] ==1:
-           TP += 1
-        elif y_actual[i][focusix]==1 and np.all(y_actual[i]!=y_hat[i]):
-           FN += 1
-        elif np.all(y_actual[i]==y_hat[i]) and y_hat[i][focusix] ==0:
-           TN += 1
-        elif y_actual[i][focusix]==0 and np.all(y_actual[i]!=y_hat[i]):
-           FP += 1
-
-    return(TP, FP, TN, FN)
-
-def MyEvaluation(y_test,predicted):
-    def norm_me(x):
-        if str(type(x)).find("int")>-1:
-            return x
-        zix = np.argmax(x)
-        x1 = [0]*len(x)
-        x1[zix] = 1
-        return x1
-    predicted = [norm_me(x) for x in predicted]
-    predicted = np.array(predicted,dtype="uint8")
-
-    target_names  = ['normal','malware']
-    inv_map = {v: k for k, v in KLABEL.items()}
-    target_names = [inv_map[x] for x in range(WORKING_KLABEL)]
-    result = classification_report(y_test,predicted,target_names=target_names)
-    print result
-
-    averagelabel = 'binary'
-    if B_MULTICLASS: averaegelabel = "macro"
-
-    v_precision = precision_score(y_test,predicted, average=averagelabel)
-    v_recall = recall_score(y_test,predicted, average=averagelabel)    
-
-    (TP, FP, TN, FN) = perf_measure(y_test, predicted,KLABEL["malicious"])
-    return v_precision,v_recall,TP, FP, TN, FN
-
-def getSaveNames(learner,datapath,note,score):
-    m_name = learner.split(".")[0]
-    fname = datapath.replace("/","-").replace("\\","-").replace("\\","-").replace(".","").replace(".","").strip("-")
-    fnameMODEL = "M_"+ m_name+"_"+fname+"_"+note
-
-    maxprecision = min(4,len(str(score)))
-    fnameWeight = fnameMODEL+'_E'+str(score)[0:maxprecision]
-
-    return fnameMODEL,fnameWeight
-
-def Dump(model,fnameMODEL,fnameWeight):
-    if str(type(model)).find("sklearn.")==-1:
-        from keras.models import Sequential
-        from keras.layers.core import Dense, Dropout, Activation
-        from keras.optimizers import SGD
-        json_string = model.to_json()
-        fm = open(fnameMODEL+".json","w")
-        fm.write(json_string)
-        fm.close()
-    
-        model.save_weights(fnameWeight+".hdf5",overwrite=True)
-    else:
-        from sklearn.externals import joblib
-        def ensure_dir(f):
-            d = os.path.dirname(f)
-            if not os.path.exists(d):
-                os.makedirs(d)
-        ensure_dir('./skmodel/')
-        joblib.dump(model, "./skmodel/"+fnameMODEL+".pkl",compress=3)
-
-def Log(message):
-    fout = open("__DEEPWRS_learning.elog","a")
-    fout.write(  "\t".join( [str(x) for x in message]  )+"\n" )
-    fout.close()
-
-class LogData:
-
-    def __init__(self):
-        self.logCMD = ()#("CMD",sys.argv[0],sys.argv[1])
-        self.logData = ()# ('DATA',data.shape)
-        self.logEXP = ()# ('EXP',nb_folds)
-        self.logLoad = ()# ('PEF',t0,t1-t0)
-        self.logTrainingErr = ()# ('T',scorearr0,np.mean(scorearr0),np.std(scorearr0))
-        self.logValidationErr = ()# ('V',scorearr,np.mean(scorearr),np.std(scorearr))
-        self.logPrecision = ()# ('Precision',precision_arr,np.mean(precision_arr),np.std(precision_arr))
-        self.logRecall =  ()# ('Recall',recall_arr,np.mean(recall_arr),np.std(recall_arr))
-        self.logR4N =  ()#("T",FourT_arr)
-        self.logBVT = ()# BestValidationTest
-        self.logTrainingTime = ()# ('Time',timearr,np.mean(timearr) )
-        self.logModel =  ()# ('DEEP',DEEP_AVF,DEEP_DROPOUTR,DEEP_SGDLR,DEEP_EPOCH,DEEP_BSIZE,D_CLASS_NORMALW)
-        self.logNote = ()#  ('NOTE',NOTE)
-        self.logSave = ()# ('Model',fnameMODEL,fnameWeight)
-        self.logTest = ()
-
-    def getLogList(self):
-        logs = [attr for attr in dir(LogData()) if not callable(attr) and not attr.startswith("__")]
-        print logs
-
-    def doprint(self):
-
-        self.logModel = ("MODEL",":".join( [str(x) for x in self.logModel] ) )
-        self.logSave = ("SAVE",":".join( [str(x) for x in self.logSave] ) )
-        
-        Log(self.logCMD+self.logData+self.logEXP+self.logLoad+self.logTrainingErr+self.logValidationErr+self.logPrecision+self.logRecall+self.logR4N+self.logTrainingTime+self.logModel+self.logNote+self.logSave+self.logTest+self.logBVT)        
-
-def CalcF1Score(p,r):
-    if (p+r)==0: return 0
-    return 2.0*p*r/(p+r)
-
-def DoKFold(data,label,myLearnandValidate):
-    model = None
-    f1max = 0
-    kfolds = KFold( data.shape[0] , nb_folds)
-    for FID, (trainix, validix) in enumerate(kfolds):
-        print "#\tFold:", FID, " total ", nb_folds
-
-        t2 = timeit.default_timer()
-        X_train = data[trainix]
-        y_train = label[trainix]
-        X_test = data[validix]
-        y_test = label[validix]
-        
-        score0,score1,v_precision,v_recall,TP, FP, TN, FN, model = myLearnandValidate(X_train,y_train,X_test,y_test)
-
-        ARR_score0.append(score0)
-        ARR_score1.append(score1)
-        ARR_4N.append( ",".join([str(x) for x in (TP, FP, TN, FN)] ) )
-        ARR_tr_precision.append(v_precision)
-        ARR_tr_recall.append(v_recall)
-
-        t3 = timeit.default_timer()
-        ARR_rtime.append(t3-t2)
-
-        f1 = CalcF1Score(v_precision,v_recall) 
-        if f1>f1max:
-            f1max = f1
-            model = model
-        print "#\t",f1,v_precision,v_recall,TP, FP, TN, FN
-
-    return f1,model
-
-def ExpFunc(path1,myLearnandValidate,bIsMulticlass=True,dropcolumns=[]):
-
-    global B_MULTICLASS
-    B_MULTICLASS = bIsMulticlass
-
-    # LOAD DATA
-    t0 = timeit.default_timer()
-    data, label = Process(path1,bBalance,bIsMulticlass,dropcolumns)
-    
-    t1 = timeit.default_timer()
-
-    # DO K FOLD
-    f1 = 0
-    model_bv = None
-    if nb_folds>0:
-        f1, model_bv = DoKFold(data,label,myLearnandValidate)
-
-    # LOAD Test Data
-    if os.path.exists(path1+"test"):
-        tdata, tlabel = Process(path1+"test/",bBalance,bIsMulticlass,dropcolumns)
-    else:
-        tdata, tlabel = None, None
-
-    # Test using the best fold
-    f3,vb_precision,vb_recall,vbTP, vbFP, vbTN, vbFN = 0,0,0,0,0,0,0
-    if not tdata is None and not model_bv is None:
-        predicted_vb = model_bv.predict(tdata)
-        vb_precision,vb_recall,vbTP, vbFP, vbTN, vbFN = MyEvaluation(tlabel,predicted_vb)
-        f3 = CalcF1Score(vb_precision,vb_recall)
-
-    # TRAINING and TESTING
-    score0,score1,t_precision,t_recall,tTP, tFP, tTN, tFN, model = myLearnandValidate(data,label,tdata,tlabel,False)
-    f4 = CalcF1Score(t_precision,t_recall)
-    print "#\tF1Score: BestFold: ",f3,"\tAllData:",f4
-
-    # Log and Serialization
-    fnameMODEL,fnameWeight = getSaveNames(sys.argv[0],sys.argv[1],NOTE,score1)
-    Dump(model,fnameMODEL,fnameWeight)
-
-    # LOG
-    logdata = LogData()
-
-    logdata.logCMD = ("CMD",sys.argv[0],sys.argv[1])
-    logdata.logData = ('DATA',data.shape)
-    logdata.logExp = ('EXP',nb_folds)
-    tprint = datetime.datetime.fromtimestamp(t1).strftime('%Y-%m-%d %H:%M:%S')
-    logdata.logLoad = ('LOAD',tprint,t1-t0)
-
-    logdata.logTrainingErr =  ('TrainErr',ARR_score0,np.mean(ARR_score0),np.std(ARR_score0))
-    logdata.logValidationErr =  ('ValidErr',ARR_score1,np.mean(ARR_score1),np.std(ARR_score1))
-    logdata.logPrecision = ('Precision',ARR_tr_precision,np.mean(ARR_tr_precision),np.std(ARR_tr_precision))
-    logdata.logRecall =  ('Recall',ARR_tr_recall,np.mean(ARR_tr_recall),np.std(ARR_tr_recall))
-    logdata.logR4N =  ("R4N",ARR_4N)
-    logdata.logTrainingTime =  ('TTime',ARR_rtime,np.mean(ARR_rtime) )
-    logdata.logNote =   ('NOTE',NOTE)
-    logdata.logTest = ("Test",t_precision,t_recall,tTP, tFP, tTN, tFN)
-    logdata.logSave = (fnameMODEL,fnameWeight)
-    logdata.logBVT = ("BVT",vb_precision,vb_recall,vbTP, vbFP, vbTN, vbFN)
-    return logdata
+    # Standard file format stores sha1 in column 0.
+    features_df = df.iloc[:, 1:].copy()
+    features_df = features_df.apply(pd.to_numeric, errors="coerce").fillna(0.0)
+    return features_df
 
 
+def load_dataset(dataset_dir: str | Path, drop_columns: Sequence[int] | None = None) -> Dataset:
+    """Load and merge all known class files from a folder.
 
+    Args:
+        dataset_dir: Directory containing `normal.vlog` and `malicious.vlog`.
+        drop_columns: 1-based feature column indices to drop.
+    """
+    dataset_path = Path(dataset_dir)
+    if not dataset_path.exists():
+        raise FileNotFoundError(f"Dataset directory not found: {dataset_path}")
+
+    matrices: List[np.ndarray] = []
+    labels: List[np.ndarray] = []
+    feature_names: List[str] | None = None
+
+    for name, label in LABEL_MAP.items():
+        file_path = dataset_path / f"{name}.vlog"
+        if not file_path.exists():
+            continue
+
+        df = _parse_vlog_file(file_path)
+        if feature_names is None:
+            feature_names = [f"f{i+1}" for i in range(df.shape[1])]
+
+        matrices.append(df.to_numpy(dtype=np.float64))
+        labels.append(np.full((df.shape[0],), label, dtype=np.uint8))
+
+    if not matrices:
+        expected = ", ".join(f"{name}.vlog" for name in LABEL_MAP)
+        raise ValueError(f"No class files found in {dataset_path}. Expected one of: {expected}")
+
+    X = np.vstack(matrices)
+    y = np.concatenate(labels)
+
+    if drop_columns:
+        # Convert to 0-based indices.
+        drop_ix = sorted({idx - 1 for idx in drop_columns if idx > 0})
+        X = np.delete(X, drop_ix, axis=1)
+        if feature_names is not None:
+            feature_names = [name for i, name in enumerate(feature_names) if i not in set(drop_ix)]
+
+    rng = np.random.default_rng(seed=1571)
+    order = rng.permutation(len(X))
+    X = X[order]
+    y = y[order]
+
+    return Dataset(features=X, labels=y, feature_names=feature_names or [])
+
+
+def build_model() -> LogisticRegression:
+    """Create a strong baseline model for binary classification."""
+    return LogisticRegression(
+        solver="liblinear",
+        class_weight="balanced",
+        random_state=1571,
+        max_iter=1000,
+    )
+
+
+def evaluate(model: LogisticRegression, X: np.ndarray, y: np.ndarray) -> EvaluationResult:
+    predictions = model.predict(X)
+    precision = precision_score(y, predictions, zero_division=0)
+    recall = recall_score(y, predictions, zero_division=0)
+    f1 = f1_score(y, predictions, zero_division=0)
+    confusion = confusion_matrix(y, predictions)
+    report = classification_report(y, predictions, target_names=["normal", "malicious"], zero_division=0)
+    return EvaluationResult(precision=precision, recall=recall, f1=f1, confusion=confusion, report=report)
+
+
+def cross_validate(dataset: Dataset, folds: int) -> List[EvaluationResult]:
+    if folds < 2:
+        raise ValueError("folds must be >= 2 for cross-validation")
+
+    cv = KFold(n_splits=folds, shuffle=True, random_state=1571)
+    results: List[EvaluationResult] = []
+
+    for train_idx, valid_idx in cv.split(dataset.features):
+        model = build_model()
+        model.fit(dataset.features[train_idx], dataset.labels[train_idx])
+        results.append(evaluate(model, dataset.features[valid_idx], dataset.labels[valid_idx]))
+
+    return results
+
+
+def save_artifacts(
+    model: LogisticRegression,
+    metrics: dict,
+    output_dir: str | Path,
+    run_name: str,
+) -> Tuple[Path, Path]:
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    model_path = output_path / f"{run_name}_model.pkl"
+    metrics_path = output_path / f"{run_name}_metrics.json"
+
+    with model_path.open("wb") as f:
+        pickle.dump(model, f)
+
+    with metrics_path.open("w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2)
+
+    return model_path, metrics_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy>=1.23
+pandas>=1.5
+scikit-learn>=1.2


### PR DESCRIPTION
### Motivation
- Bring an older experimental demo up to a recruiter-ready standard by improving readability, reproducibility, and CLI ergonomics. 
- Replace ad-hoc training scaffolding with a small, maintainable baseline pipeline that is easy to explain on camera. 
- Provide deterministic behavior, clear metrics outputs, and simple artifact persistence for model and metrics. 

### Description
- Rewrote core training utilities in `learning/learning_kernel.py` with typed `@dataclass` interfaces (`Dataset`, `EvaluationResult`), robust `.vlog` parsing (`_parse_vlog_file`), deterministic shuffling, optional feature dropping, a `build_model()` factory that returns a `LogisticRegression`, `evaluate()` helper, `cross_validate()` wrapper, and `save_artifacts()` to persist model and metrics. 
- Replaced the legacy script with a CLI entrypoint `learning/happycat.py` using `argparse` and exposing `--dataset`, `--folds`, `--run-name`, `--output-dir`, `--drop-columns`, and `--test-subdir`, plus CV summary aggregation and optional test-set evaluation. 
- Updated `README.md` to a concise, recruiter-friendly quickstart and project overview, and added `requirements.txt` and `.gitignore` for onboarding and repository hygiene. 
- Kept API and outputs production-like (`.pkl` model + `.json` metrics in an artifacts directory) to make demonstration and review straightforward. 

### Testing
- Ran bytecode compilation with `python -m py_compile learning/happycat.py learning/learning_kernel.py`, which completed successfully. 
- Attempted to run the end-to-end example `python learning/happycat.py --dataset dataset/unittest --folds 3 --run-name unittest_demo`, which failed in this environment due to missing binary dependencies (`ModuleNotFoundError: No module named 'numpy'`). 
- Attempted to install dependencies via `python -m pip install -r requirements.txt`, which was blocked by the environment/network proxy and therefore could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace84add1883339f83e05ab253fed7)